### PR TITLE
Amended scope and removed .values method

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -109,7 +109,7 @@ define sasl::application (
 
   # Build up an array of packages that need to be installed based on the
   # chosen authentication mechanisms
-  $packages = split(inline_template('<%= scope.lookupvar("::sasl::mech_packages").select { |k| @mech_list.include?(k) }.values.uniq.join(",") %>'), ',') # lint:ignore:80chars
+  $packages = split(inline_template('<%= scope.lookupvar("::sasl::params::mech_packages").select { |k| @mech_list.include?(k) }.uniq.join(",") %>'), ',') # lint:ignore:80chars
   ensure_packages($packages)
   Package[$packages] -> File[$service_file]
 


### PR DESCRIPTION
Thanks for explanation, I've amended variable scope by adding ::params. 
It was not sufficient: I got the same message "Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse inline template: undefined method `values' for []:Array at /etc/puppet/environments/bacon/modules/sasl/manifests/application.pp:112 on node ...".
It looks like after removing ".values" from this line fixed the problem.
