### PR TITLE
Amended scope of mech_packages to be ::sasl::params

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -109,7 +109,7 @@ define sasl::application (
 
   # Build up an array of packages that need to be installed based on the
   # chosen authentication mechanisms
-  $packages = split(inline_template('<%= scope.lookupvar("::sasl::mech_packages").select { |k| @mech_list.include?(k) }.values.uniq.join(",") %>'), ',') # lint:ignore:80chars
+  $packages = split(inline_template('<%= Hash[scope.lookupvar("::sasl::params::mech_packages").select { |k,v| @mech_list.include?(k) }].values.uniq.join(",") %>'), ',') # lint:ignore:80chars
   ensure_packages($packages)
   Package[$packages] -> File[$service_file]
 


### PR DESCRIPTION
Scope is fixed, as @bodgit proposed. 
But after that my puppet on RedHat 7 was complaining "Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse inline template: undefined method `values' for []:Array at /etc/puppet/environments/bacon/modules/sasl/manifests/application.pp:112 on node ..."
It looks like this was caused by type casting of scope.lookupvar(<hash>).select{ |k,v| block} to Array type. Adding "Hash[...]" seems to help.
