### PR TITLE
Make salsauthd threads a configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ include ::sasl
 
 ##### `mechanism`
 
+##### `threads`
+
 ##### `package_name`
 
 ##### `service_name`

--- a/manifests/authd.pp
+++ b/manifests/authd.pp
@@ -1,6 +1,7 @@
 #
 class sasl::authd (
   $mechanism,
+  $threads                 = $::sasl::params::saslauthd_threads,
   $package_name            = $::sasl::params::saslauthd_package,
   $service_name            = $::sasl::params::saslauthd_service,
   $socket                  = $::sasl::params::saslauthd_socket,
@@ -51,6 +52,7 @@ class sasl::authd (
   }
 
   validate_re($mechanism, $::sasl::params::saslauthd_mechanisms)
+  validate_integer($threads, undef, 1)
   validate_string($package_name)
   validate_string($service_name)
   validate_absolute_path($socket)

--- a/manifests/authd/config.pp
+++ b/manifests/authd/config.pp
@@ -3,6 +3,7 @@ class sasl::authd::config {
 
   $socket                  = $::sasl::authd::socket
   $mechanism               = $::sasl::authd::mechanism
+  $threads                 = $::sasl::authd::threads
   $ldap_conf_file          = $::sasl::authd::ldap_conf_file
   $ldap_auth_method        = $::sasl::authd::ldap_auth_method
   $ldap_bind_dn            = $::sasl::authd::ldap_bind_dn
@@ -51,7 +52,10 @@ class sasl::authd::config {
 
   case $::osfamily { # lint:ignore:case_without_default
     'RedHat': {
-      $flags = $mech_options
+      $flags = $threads ? {
+        $::sasl::params::saslauthd_threads => $mech_options,
+        default                            => strip("${mech_options} -n ${threads}") # lint:ignore:80chars
+      }
 
       file { '/etc/sysconfig/saslauthd':
         ensure  => file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class sasl::params {
 
   $saslauthd_service        = 'saslauthd'
   $saslauthd_ldap_conf_file = '/etc/saslauthd.conf'
+  $saslauthd_threads        = 5
 
   case $::osfamily {
     'RedHat': {

--- a/spec/classes/sasl_authd_spec.rb
+++ b/spec/classes/sasl_authd_spec.rb
@@ -22,444 +22,482 @@ describe 'sasl::authd' do
     it { expect { should compile }.to raise_error(/not supported on an Unsupported/) }
   end
 
-  context 'with pam mechanism' do
-    let(:params) do
-      {
-        :mechanism => 'pam'
-      }
-    end
-
-    context 'on RedHat' do
-      let(:facts) do
+  [5, 10].each do |threads|
+    context "with #{threads} threads" do
+      let(:params) do
         {
-          :osfamily => 'RedHat'
+          :threads => threads
         }
       end
 
-      [6, 7].each do |version|
-        context "version #{version}", :compile do
-
-          let(:pre_condition) do
-            'include ::sasl'
-          end
-
-          let(:facts) do
-            super().merge(
-              {
-                :operatingsystemmajrelease => version
-              }
-            )
-          end
-
-          it_behaves_like 'sasl::authd'
-
-          it { should contain_file('/etc/saslauthd.conf').with_ensure('absent') }
-
-          case version
-          when 6
-            it do
-              should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
-
-                SOCKETDIR="/var/run/saslauthd"
-                MECH="pam"
-                FLAGS=""
-              EOS
-            end
-          else
-            it do
-              should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
-
-                SOCKETDIR="/run/saslauthd"
-                MECH="pam"
-                FLAGS=""
-              EOS
-            end
-          end
-
-          it { should contain_package('cyrus-sasl') }
+      context 'with pam mechanism' do
+        let(:params) do
+          super().merge(
+            {
+              :mechanism => 'pam'
+            }
+          )
         end
-      end
-    end
 
-    context 'on Ubuntu' do
-      let(:facts) do
-        {
-          :osfamily        => 'Debian',
-          :operatingsystem => 'Ubuntu',
-          :lsbdistid       => 'Ubuntu'
-        }
-      end
-
-      ['precise', 'trusty'].each do |codename|
-        context "#{codename}", :compile do
-
-          let(:pre_condition) do
-            'include ::sasl'
-          end
-
+        context 'on RedHat' do
           let(:facts) do
-            super().merge(
-              {
-                :lsbdistcodename => codename
-              }
-            )
+            {
+              :osfamily => 'RedHat'
+            }
           end
 
-          it_behaves_like 'sasl::authd'
+          [6, 7].each do |version|
+            context "version #{version}", :compile do
 
-          it do
-            should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-              # !!! Managed by Puppet !!!
+              let(:pre_condition) do
+                'include ::sasl'
+              end
 
-              START=yes
-              DESC="SASL Authentication Daemon"
-              NAME="saslauthd"
-              MECHANISMS="pam"
-              MECH_OPTIONS=""
-              THREADS=5
-              OPTIONS="-c -m /var/run/saslauthd"
-            EOS
-          end
-          it { should contain_file('/etc/saslauthd.conf').with_ensure('absent') }
-          it { should contain_package('sasl2-bin') }
-        end
-      end
-    end
+              let(:facts) do
+                super().merge(
+                  {
+                    :operatingsystemmajrelease => version
+                  }
+                )
+              end
 
-    context 'on Debian' do
-      let(:facts) do
-        {
-          :osfamily        => 'Debian',
-          :operatingsystem => 'Debian',
-          :lsbdistid       => 'Debian'
-        }
-      end
+              it_behaves_like 'sasl::authd'
 
-      ['squeeze', 'wheezy'].each do |codename|
-        context "#{codename}", :compile do
+              it { should contain_file('/etc/saslauthd.conf').with_ensure('absent') }
 
-          let(:pre_condition) do
-            'include ::sasl'
-          end
+              case version
+              when 6
+                case threads
+                when 5
+                  it do
+                    should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                      # !!! Managed by Puppet !!!
 
-          let(:facts) do
-            super().merge(
-              {
-                :lsbdistcodename => codename
-              }
-            )
-          end
+                      SOCKETDIR="/var/run/saslauthd"
+                      MECH="pam"
+                      FLAGS=""
+                    EOS
+                  end
+                else
+                  it do
+                    should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                      # !!! Managed by Puppet !!!
 
-          it_behaves_like 'sasl::authd'
+                      SOCKETDIR="/var/run/saslauthd"
+                      MECH="pam"
+                      FLAGS="-n #{threads}"
+                    EOS
+                  end
+                end
+              else
+                case threads
+                when 5
+                  it do
+                    should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                      # !!! Managed by Puppet !!!
 
-          it do
-            should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-              # !!! Managed by Puppet !!!
+                      SOCKETDIR="/run/saslauthd"
+                      MECH="pam"
+                      FLAGS=""
+                    EOS
+                  end
+                else
+                  it do
+                    should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                      # !!! Managed by Puppet !!!
 
-              START=yes
-              DESC="SASL Authentication Daemon"
-              NAME="saslauthd"
-              MECHANISMS="pam"
-              MECH_OPTIONS=""
-              THREADS=5
-              OPTIONS="-c -m /var/run/saslauthd"
-            EOS
-          end
-          it { should contain_file('/etc/saslauthd.conf').with_ensure('absent') }
-          it { should contain_package('sasl2-bin') }
-        end
-      end
-    end
-  end
+                      SOCKETDIR="/run/saslauthd"
+                      MECH="pam"
+                      FLAGS="-n #{threads}"
+                    EOS
+                  end
+                end
+              end
 
-  context 'with ldap mechanism' do
-    let(:params) do
-      {
-        :mechanism => 'ldap'
-      }
-    end
-
-    context 'on RedHat' do
-      let(:facts) do
-        {
-          :osfamily => 'RedHat'
-        }
-      end
-
-      [6, 7].each do |version|
-        context "version #{version}", :compile do
-
-          let(:pre_condition) do
-            'include ::sasl'
-          end
-
-          let(:facts) do
-            super().merge(
-              {
-                :operatingsystemmajrelease => version
-              }
-            )
-          end
-
-          context 'with default parameters' do
-
-            it_behaves_like 'sasl::authd'
-
-            it do
-              should contain_file('/etc/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
-
-              EOS
+              it { should contain_package('cyrus-sasl') }
             end
+          end
+        end
 
-            case version
-            when 6
+        context 'on Ubuntu' do
+          let(:facts) do
+            {
+              :osfamily        => 'Debian',
+              :operatingsystem => 'Ubuntu',
+              :lsbdistid       => 'Ubuntu'
+            }
+          end
+
+          ['precise', 'trusty'].each do |codename|
+            context "#{codename}", :compile do
+
+              let(:pre_condition) do
+                'include ::sasl'
+              end
+
+              let(:facts) do
+                super().merge(
+                  {
+                    :lsbdistcodename => codename
+                  }
+                )
+              end
+
+              it_behaves_like 'sasl::authd'
+
               it do
-                should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
                   # !!! Managed by Puppet !!!
 
-                  SOCKETDIR="/var/run/saslauthd"
-                  MECH="ldap"
-                  FLAGS=""
+                  START=yes
+                  DESC="SASL Authentication Daemon"
+                  NAME="saslauthd"
+                  MECHANISMS="pam"
+                  MECH_OPTIONS=""
+                  THREADS=#{threads}
+                  OPTIONS="-c -m /var/run/saslauthd"
                 EOS
               end
-            else
-              it do
-                should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-                  # !!! Managed by Puppet !!!
-
-                  SOCKETDIR="/run/saslauthd"
-                  MECH="ldap"
-                  FLAGS=""
-                EOS
-              end
+              it { should contain_file('/etc/saslauthd.conf').with_ensure('absent') }
+              it { should contain_package('sasl2-bin') }
             end
+          end
+        end
 
-            it { should contain_package('cyrus-sasl') }
+        context 'on Debian' do
+          let(:facts) do
+            {
+              :osfamily        => 'Debian',
+              :operatingsystem => 'Debian',
+              :lsbdistid       => 'Debian'
+            }
           end
 
-          context 'with alternate configuration file and specified parameters' do
-            let(:params) do
-              super().merge(
-                {
-                  :ldap_conf_file => '/tmp/saslauthd.conf'
-                  # TODO
-                }
-              )
-            end
+          ['squeeze', 'wheezy'].each do |codename|
+            context "#{codename}", :compile do
 
-            it_behaves_like 'sasl::authd'
+              let(:pre_condition) do
+                'include ::sasl'
+              end
 
-            it { should_not contain_file('/etc/saslauthd.conf') }
-            it do
-              should contain_file('/tmp/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
+              let(:facts) do
+                super().merge(
+                  {
+                    :lsbdistcodename => codename
+                  }
+                )
+              end
 
-              EOS
-            end
+              it_behaves_like 'sasl::authd'
 
-            case version
-            when 6
               it do
-                should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
                   # !!! Managed by Puppet !!!
 
-                  SOCKETDIR="/var/run/saslauthd"
-                  MECH="ldap"
-                  FLAGS="-O /tmp/saslauthd.conf"
+                  START=yes
+                  DESC="SASL Authentication Daemon"
+                  NAME="saslauthd"
+                  MECHANISMS="pam"
+                  MECH_OPTIONS=""
+                  THREADS=#{threads}
+                  OPTIONS="-c -m /var/run/saslauthd"
                 EOS
               end
-            else
-              it do
-                should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-                  # !!! Managed by Puppet !!!
-
-                  SOCKETDIR="/run/saslauthd"
-                  MECH="ldap"
-                  FLAGS="-O /tmp/saslauthd.conf"
-                EOS
-              end
+              it { should contain_file('/etc/saslauthd.conf').with_ensure('absent') }
+              it { should contain_package('sasl2-bin') }
             end
-
-            it { should contain_package('cyrus-sasl') }
           end
         end
       end
-    end
 
-    context 'on Ubuntu' do
-      let(:facts) do
-        {
-          :osfamily        => 'Debian',
-          :operatingsystem => 'Ubuntu',
-          :lsbdistid       => 'Ubuntu'
-        }
-      end
+      context 'with ldap mechanism' do
+        let(:params) do
+          {
+            :mechanism => 'ldap'
+          }
+        end
 
-      ['precise', 'trusty'].each do |codename|
-        context "#{codename}", :compile do
-
-          let(:pre_condition) do
-            'include ::sasl'
-          end
-
+        context 'on RedHat' do
           let(:facts) do
-            super().merge(
-              {
-                :lsbdistcodename => codename
-              }
-            )
+            {
+              :osfamily => 'RedHat'
+            }
           end
 
-          context 'with default parameters' do
+          [6, 7].each do |version|
+            context "version #{version}", :compile do
 
-            it_behaves_like 'sasl::authd'
+              let(:pre_condition) do
+                'include ::sasl'
+              end
 
-            it do
-              should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
+              let(:facts) do
+                super().merge(
+                  {
+                    :operatingsystemmajrelease => version
+                  }
+                )
+              end
 
-                START=yes
-                DESC="SASL Authentication Daemon"
-                NAME="saslauthd"
-                MECHANISMS="ldap"
-                MECH_OPTIONS=""
-                THREADS=5
-                OPTIONS="-c -m /var/run/saslauthd"
-              EOS
+              context 'with default parameters' do
+
+                it_behaves_like 'sasl::authd'
+
+                it do
+                  should contain_file('/etc/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                  EOS
+                end
+
+                case version
+                when 6
+                  it do
+                    should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                      # !!! Managed by Puppet !!!
+
+                      SOCKETDIR="/var/run/saslauthd"
+                      MECH="ldap"
+                      FLAGS=""
+                    EOS
+                  end
+                else
+                  it do
+                    should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                      # !!! Managed by Puppet !!!
+
+                      SOCKETDIR="/run/saslauthd"
+                      MECH="ldap"
+                      FLAGS=""
+                    EOS
+                  end
+                end
+
+                it { should contain_package('cyrus-sasl') }
+              end
+
+              context 'with alternate configuration file and specified parameters' do
+                let(:params) do
+                  super().merge(
+                    {
+                      :ldap_conf_file => '/tmp/saslauthd.conf'
+                      # TODO
+                    }
+                  )
+                end
+
+                it_behaves_like 'sasl::authd'
+
+                it { should_not contain_file('/etc/saslauthd.conf') }
+                it do
+                  should contain_file('/tmp/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                  EOS
+                end
+
+                case version
+                when 6
+                  it do
+                    should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                      # !!! Managed by Puppet !!!
+
+                      SOCKETDIR="/var/run/saslauthd"
+                      MECH="ldap"
+                      FLAGS="-O /tmp/saslauthd.conf"
+                    EOS
+                  end
+                else
+                  it do
+                    should contain_file('/etc/sysconfig/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                      # !!! Managed by Puppet !!!
+
+                      SOCKETDIR="/run/saslauthd"
+                      MECH="ldap"
+                      FLAGS="-O /tmp/saslauthd.conf"
+                    EOS
+                  end
+                end
+
+                it { should contain_package('cyrus-sasl') }
+              end
             end
-            it do
-              should contain_file('/etc/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
-
-              EOS
-            end
-            it { should contain_package('sasl2-bin') }
-          end
-
-          context 'with alternate configuration file and specified parameters' do
-            let(:params) do
-              super().merge(
-                {
-                  :ldap_conf_file => '/tmp/saslauthd.conf'
-                  # TODO
-                }
-              )
-            end
-
-            it_behaves_like 'sasl::authd'
-
-            it do
-              should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
-
-                START=yes
-                DESC="SASL Authentication Daemon"
-                NAME="saslauthd"
-                MECHANISMS="ldap"
-                MECH_OPTIONS="-O /tmp/saslauthd.conf"
-                THREADS=5
-                OPTIONS="-c -m /var/run/saslauthd"
-              EOS
-            end
-            it { should_not contain_file('/etc/saslauthd.conf') }
-            it do
-              should contain_file('/tmp/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
-
-              EOS
-            end
-            it { should contain_package('sasl2-bin') }
           end
         end
-      end
-    end
 
-    context 'on Debian' do
-      let(:facts) do
-        {
-          :osfamily        => 'Debian',
-          :operatingsystem => 'Debian',
-          :lsbdistid       => 'Debian'
-        }
-      end
-
-      ['squeeze', 'wheezy'].each do |codename|
-        context "#{codename}", :compile do
-
-          let(:pre_condition) do
-            'include ::sasl'
-          end
-
+        context 'on Ubuntu' do
           let(:facts) do
-            super().merge(
-              {
-                :lsbdistcodename => codename
-              }
-            )
+            {
+              :osfamily        => 'Debian',
+              :operatingsystem => 'Ubuntu',
+              :lsbdistid       => 'Ubuntu'
+            }
           end
 
-          context 'with default parameters' do
+          ['precise', 'trusty'].each do |codename|
+            context "#{codename}", :compile do
 
-            it_behaves_like 'sasl::authd'
+              let(:pre_condition) do
+                'include ::sasl'
+              end
 
-            it do
-              should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
+              let(:facts) do
+                super().merge(
+                  {
+                    :lsbdistcodename => codename
+                  }
+                )
+              end
 
-                START=yes
-                DESC="SASL Authentication Daemon"
-                NAME="saslauthd"
-                MECHANISMS="ldap"
-                MECH_OPTIONS=""
-                THREADS=5
-                OPTIONS="-c -m /var/run/saslauthd"
-              EOS
+              context 'with default parameters' do
+
+                it_behaves_like 'sasl::authd'
+
+                it do
+                  should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                    START=yes
+                    DESC="SASL Authentication Daemon"
+                    NAME="saslauthd"
+                    MECHANISMS="ldap"
+                    MECH_OPTIONS=""
+                    THREADS=5
+                    OPTIONS="-c -m /var/run/saslauthd"
+                  EOS
+                end
+                it do
+                  should contain_file('/etc/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                  EOS
+                end
+                it { should contain_package('sasl2-bin') }
+              end
+
+              context 'with alternate configuration file and specified parameters' do
+                let(:params) do
+                  super().merge(
+                    {
+                      :ldap_conf_file => '/tmp/saslauthd.conf'
+                      # TODO
+                    }
+                  )
+                end
+
+                it_behaves_like 'sasl::authd'
+
+                it do
+                  should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                    START=yes
+                    DESC="SASL Authentication Daemon"
+                    NAME="saslauthd"
+                    MECHANISMS="ldap"
+                    MECH_OPTIONS="-O /tmp/saslauthd.conf"
+                    THREADS=5
+                    OPTIONS="-c -m /var/run/saslauthd"
+                  EOS
+                end
+                it { should_not contain_file('/etc/saslauthd.conf') }
+                it do
+                  should contain_file('/tmp/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                  EOS
+                end
+                it { should contain_package('sasl2-bin') }
+              end
             end
-            it do
-              should contain_file('/etc/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
+          end
+        end
 
-              EOS
-            end
-            it { should contain_package('sasl2-bin') }
+        context 'on Debian' do
+          let(:facts) do
+            {
+              :osfamily        => 'Debian',
+              :operatingsystem => 'Debian',
+              :lsbdistid       => 'Debian'
+            }
           end
 
-          context 'with alternate configuration file and specified parameters' do
-            let(:params) do
-              super().merge(
-                {
-                  :ldap_conf_file => '/tmp/saslauthd.conf'
-                  # TODO
-                }
-              )
+          ['squeeze', 'wheezy'].each do |codename|
+            context "#{codename}", :compile do
+
+              let(:pre_condition) do
+                'include ::sasl'
+              end
+
+              let(:facts) do
+                super().merge(
+                  {
+                    :lsbdistcodename => codename
+                  }
+                )
+              end
+
+              context 'with default parameters' do
+
+                it_behaves_like 'sasl::authd'
+
+                it do
+                  should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                    START=yes
+                    DESC="SASL Authentication Daemon"
+                    NAME="saslauthd"
+                    MECHANISMS="ldap"
+                    MECH_OPTIONS=""
+                    THREADS=5
+                    OPTIONS="-c -m /var/run/saslauthd"
+                  EOS
+                end
+                it do
+                  should contain_file('/etc/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                  EOS
+                end
+                it { should contain_package('sasl2-bin') }
+              end
+
+              context 'with alternate configuration file and specified parameters' do
+                let(:params) do
+                  super().merge(
+                    {
+                      :ldap_conf_file => '/tmp/saslauthd.conf'
+                      # TODO
+                    }
+                  )
+                end
+
+                it_behaves_like 'sasl::authd'
+
+                it do
+                  should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                    START=yes
+                    DESC="SASL Authentication Daemon"
+                    NAME="saslauthd"
+                    MECHANISMS="ldap"
+                    MECH_OPTIONS="-O /tmp/saslauthd.conf"
+                    THREADS=5
+                    OPTIONS="-c -m /var/run/saslauthd"
+                  EOS
+                end
+                it { should_not contain_file('/etc/saslauthd.conf') }
+                it do
+                  should contain_file('/tmp/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
+                    # !!! Managed by Puppet !!!
+
+                  EOS
+                end
+                it { should contain_package('sasl2-bin') }
+              end
             end
-
-            it_behaves_like 'sasl::authd'
-
-            it do
-              should contain_file('/etc/default/saslauthd').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
-
-                START=yes
-                DESC="SASL Authentication Daemon"
-                NAME="saslauthd"
-                MECHANISMS="ldap"
-                MECH_OPTIONS="-O /tmp/saslauthd.conf"
-                THREADS=5
-                OPTIONS="-c -m /var/run/saslauthd"
-              EOS
-            end
-            it { should_not contain_file('/etc/saslauthd.conf') }
-            it do
-              should contain_file('/tmp/saslauthd.conf').with_content(<<-EOS.gsub(/^ +/, ''))
-                # !!! Managed by Puppet !!!
-
-              EOS
-            end
-            it { should contain_package('sasl2-bin') }
           end
         end
       end

--- a/templates/default.erb
+++ b/templates/default.erb
@@ -5,5 +5,5 @@ DESC="SASL Authentication Daemon"
 NAME="saslauthd"
 MECHANISMS="<%= @mechanism %>"
 MECH_OPTIONS="<%= @mech_options %>"
-THREADS=5
+THREADS=<%= @threads %>
 OPTIONS="-c -m <%= @socket %>"


### PR DESCRIPTION
The default number of 5 saslauthd threads may be inappropriate for very small or very large installations. This change makes the number of threads a configuration parameter with default 5.
