### PR TITLE
Allow use of 'external' mechanism in application configuration

### DIFF
--- a/spec/aliases/mech_spec.rb
+++ b/spec/aliases/mech_spec.rb
@@ -10,6 +10,7 @@ if Puppet.version.to_f >= 4.4
         'login',
         'ntlm',
         'plain',
+		'external'
       ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}

--- a/spec/aliases/mech_spec.rb
+++ b/spec/aliases/mech_spec.rb
@@ -10,7 +10,7 @@ if Puppet.version.to_f >= 4.4
         'login',
         'ntlm',
         'plain',
-        'external'
+        'external',
       ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}

--- a/spec/aliases/mech_spec.rb
+++ b/spec/aliases/mech_spec.rb
@@ -10,7 +10,7 @@ if Puppet.version.to_f >= 4.4
         'login',
         'ntlm',
         'plain',
-		'external'
+        'external'
       ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}

--- a/types/mech.pp
+++ b/types/mech.pp
@@ -1,2 +1,2 @@
 # @since 2.0.0
-type SASL::Mech = Enum['anonymous', 'cram-md5', 'digest-md5', 'login', 'ntlm', 'plain']
+type SASL::Mech = Enum['anonymous', 'cram-md5', 'digest-md5', 'login', 'ntlm', 'plain', 'external']


### PR DESCRIPTION
As far as I can tell the 'external' mechanism is built into the base cyrus-sasl package, so no extra tests are required.

My use case is using SSL certificates as the external mechanism for my LDAP servers to authenticate the synchronization user.
