### PR TITLE
Drop support for old Puppet versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.4.0 <6.0.0"
+      "version_requirement": ">=5.5.10 <7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Add support for 6.x versions too.