### PR TITLE
add parameter for setting the permissions of the sasl_conf_file

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -190,6 +190,14 @@ usually `/etc/saslauthd.conf`.
 
 Default value: `$::sasl::params::saslauthd_ldap_conf_file`
 
+##### `ldap_conf_file_mode`
+
+Data type: `String`
+
+file mode for the ldap_conf_file
+
+Default value: `'0644'`
+
 ##### `ldap_auth_method`
 
 Data type: `Optional[Enum['bind', 'custom', 'fastbind']]`

--- a/manifests/authd.pp
+++ b/manifests/authd.pp
@@ -33,6 +33,7 @@
 # @param hasstatus If the service supports querying the running status or not.
 # @param ldap_conf_file Path to the configuration file for LDAP configuration,
 #   usually `/etc/saslauthd.conf`.
+# @param ldap_conf_file_mode file mode for the ldap_conf_file
 # @param ldap_auth_method How to authenticate with the LDAP server.
 # @param ldap_bind_dn Distinguished name used to bind to the LDAP server.
 # @param ldap_bind_pw Password used to bind with.
@@ -82,6 +83,7 @@ class sasl::authd (
   Boolean                                             $hasstatus               = $::sasl::params::saslauthd_hasstatus,
   # ldap
   Optional[Stdlib::Absolutepath]                      $ldap_conf_file          = $::sasl::params::saslauthd_ldap_conf_file,
+  String                                              $ldap_conf_file_mode     = '0644',
   Optional[Enum['bind', 'custom', 'fastbind']]        $ldap_auth_method        = undef,
   Optional[Bodgitlib::LDAP::DN]                       $ldap_bind_dn            = undef,
   Optional[String]                                    $ldap_bind_pw            = undef,

--- a/manifests/authd/config.pp
+++ b/manifests/authd/config.pp
@@ -5,6 +5,7 @@ class sasl::authd::config {
   $mechanism               = $::sasl::authd::mechanism
   $threads                 = $::sasl::authd::threads
   $ldap_conf_file          = $::sasl::authd::ldap_conf_file
+  $ldap_conf_file_mode     = $::sasl::authd::ldap_conf_file_mode
   $ldap_auth_method        = $::sasl::authd::ldap_auth_method
   $ldap_bind_dn            = $::sasl::authd::ldap_bind_dn
   $ldap_bind_pw            = $::sasl::authd::ldap_bind_pw
@@ -100,7 +101,7 @@ class sasl::authd::config {
     ensure  => $ldap_conf_file_ensure,
     owner   => 0,
     group   => 0,
-    mode    => '0644',
+    mode    => $ldap_conf_file_mode,
     content => template('sasl/saslauthd.conf.erb'),
   }
 }

--- a/spec/classes/sasl_authd_spec.rb
+++ b/spec/classes/sasl_authd_spec.rb
@@ -117,6 +117,9 @@ describe 'sasl::authd' do
 
                 EOS
               end
+              it do
+                is_expected.to contain_file('/etc/saslauthd.conf').with_mode('0644')
+              end
 
               case facts[:osfamily]
               when 'Debian'
@@ -173,6 +176,7 @@ describe 'sasl::authd' do
               let(:params) do
                 super().merge(
                   ldap_conf_file: '/tmp/saslauthd.conf',
+                  ldap_conf_file_mode: '0600',
                   # TODO
                 )
               end
@@ -185,6 +189,9 @@ describe 'sasl::authd' do
                   # !!! Managed by Puppet !!!
 
                 EOS
+              end
+              it do
+                is_expected.to contain_file('/tmp/saslauthd.conf').with_mode('0600')
               end
 
               case facts[:osfamily]


### PR DESCRIPTION
the default permission is '0644' which makes this file world
readable since it contains a ldap password I would prefer to
set it to '0600'. This parameter allows to do so !