### PR TITLE
Install sasldb package for sasldb management if sasldb used

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -93,6 +93,9 @@ define sasl::application (
       $auxprop_package = $::sasl::auxprop_packages[$auxprop_plugin]
       ensure_packages([$auxprop_package])
       Package[$auxprop_package] -> File[$service_file]
+      if $auxprop_plugin == 'sasldb' {
+        ensure_packages([$sasldb_package])
+      }
     }
     'saslauthd': {
       # Require saslauthd if that's the method

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -94,7 +94,7 @@ define sasl::application (
       ensure_packages([$auxprop_package])
       Package[$auxprop_package] -> File[$service_file]
       if $auxprop_plugin == 'sasldb' {
-        ensure_packages([$sasldb_package])
+        ensure_packages([$::sasl::sasldb_package])
       }
     }
     'saslauthd': {


### PR DESCRIPTION
If `pwcheck_method` is `auxprop` and `auxprop_plugin` is `sasldb` then the sasldb bin package should be installed, which contains `saslpasswd2` and `sasldblistusers2` for sasldb file management.

Thank you for merging.
