### PR TITLE
Saslauthd config options

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -93,6 +93,9 @@ define sasl::application (
       $auxprop_package = $::sasl::auxprop_packages[$auxprop_plugin]
       ensure_packages([$auxprop_package])
       Package[$auxprop_package] -> File[$service_file]
+      if $auxprop_plugin == 'sasldb' {
+        ensure_packages([$sasldb_package])
+      }
     }
     'saslauthd': {
       # Require saslauthd if that's the method

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -94,7 +94,7 @@ define sasl::application (
       ensure_packages([$auxprop_package])
       Package[$auxprop_package] -> File[$service_file]
       if $auxprop_plugin == 'sasldb' {
-        ensure_packages([$sasldb_package])
+        ensure_packages([$::sasl::sasldb_package])
       }
     }
     'saslauthd': {

--- a/manifests/authd.pp
+++ b/manifests/authd.pp
@@ -80,6 +80,9 @@ class sasl::authd (
   String                                              $service_name            = $::sasl::params::saslauthd_service,
   Stdlib::Absolutepath                                $socket                  = $::sasl::params::saslauthd_socket,
   Boolean                                             $hasstatus               = $::sasl::params::saslauthd_hasstatus,
+  Boolean                                             $credcache               = $::sasl::params::saslauthd_credcache,
+  Optional[Integer[0]]                                $credcache_timeout       = undef,
+  Optional[Integer[0]]                                $credcache_size          = undef,
   # ldap
   Optional[Stdlib::Absolutepath]                      $ldap_conf_file          = $::sasl::params::saslauthd_ldap_conf_file,
   Optional[Enum['bind', 'custom', 'fastbind']]        $ldap_auth_method        = undef,

--- a/manifests/authd/config.pp
+++ b/manifests/authd/config.pp
@@ -62,11 +62,11 @@ class sasl::authd::config {
   }
 
   if $credcache_timeout {
-    $credcache_timeout_opt = '-t ${credcache_timeout}'
+    $credcache_timeout_opt = "-t ${credcache_timeout}"
   }
 
   if $credcache_size {
-    $credcache_size_opt = '-s ${credcache_size}'
+    $credcache_size_opt = "-s ${credcache_size}"
   }
 
   case $facts['os']['family'] {

--- a/manifests/authd/config.pp
+++ b/manifests/authd/config.pp
@@ -4,6 +4,9 @@ class sasl::authd::config {
   $socket                  = $::sasl::authd::socket
   $mechanism               = $::sasl::authd::mechanism
   $threads                 = $::sasl::authd::threads
+  $credcache               = $::sasl::authd::credcache
+  $credcache_timeout       = $::sasl::authd::credcache_timeout
+  $credcache_size          = $::sasl::authd::credcache_size
   $ldap_conf_file          = $::sasl::authd::ldap_conf_file
   $ldap_auth_method        = $::sasl::authd::ldap_auth_method
   $ldap_bind_dn            = $::sasl::authd::ldap_bind_dn
@@ -52,6 +55,18 @@ class sasl::authd::config {
       default     => $imap_server,
     },
     default => '',
+  }
+
+  if $credcache {
+    $credcache_opt = '-c'
+  }
+
+  if $credcache_timeout {
+    $credcache_timeout_opt = '-t ${credcache_timeout}'
+  }
+
+  if $credcache_size {
+    $credcache_size_opt = '-s ${credcache_size}'
   }
 
   case $facts['os']['family'] {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class sasl::params {
   $saslauthd_service        = 'saslauthd'
   $saslauthd_ldap_conf_file = '/etc/saslauthd.conf'
   $saslauthd_threads        = 5
+  $saslauthd_credcache      = true
 
   case $facts['os']['family'] {
     'RedHat': {

--- a/templates/default.erb
+++ b/templates/default.erb
@@ -6,4 +6,4 @@ NAME="saslauthd"
 MECHANISMS="<%= @mechanism %>"
 MECH_OPTIONS="<%= @mech_options %>"
 THREADS=<%= @threads %>
-OPTIONS="-c -m <%= @socket %>"
+OPTIONS="<%= @credcache_opt %> <%= @credcache_timeout_opt %> <%= @credcache_size_opt %> -m <%= @socket %>"

--- a/templates/sysconfig.erb
+++ b/templates/sysconfig.erb
@@ -2,4 +2,4 @@
 
 SOCKETDIR="<%= @socket %>"
 MECH="<%= @mechanism %>"
-FLAGS="<%= @flags %>"
+FLAGS="<%= @flags %> <%= @credcache_opt %> <%= @credcache_timeout_opt %> <%= @credcache_size_opt %>"


### PR DESCRIPTION
This PR includes the changes from PR #21.

This PR adds options to enable/disable credential cache of saslauthd and credential cache timeout and credential cache size.

Thank you for merging.